### PR TITLE
Make TLS version and cache configurable.

### DIFF
--- a/oidc-client/pom.xml
+++ b/oidc-client/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+	  <artifactId>spring-boot-starter-actuator</artifactId>
+	</dependency>
+
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>

--- a/oidc-client/src/main/java/org/glite/authz/oidc/client/ClientConfiguration.java
+++ b/oidc-client/src/main/java/org/glite/authz/oidc/client/ClientConfiguration.java
@@ -34,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -59,6 +57,9 @@ public class ClientConfiguration {
 
   @Value("${x509.trustAnchorsRefreshMsec}")
   private Long trustAnchorsRefreshInterval;
+
+  @Value("${tls.version}")
+  private String tlsVersion;
 
   @Autowired
   private ClientProperties oidcConfig;
@@ -125,7 +126,7 @@ public class ClientConfiguration {
   public SSLContext sslContext() {
 
     try {
-      SSLContext context = SSLContext.getInstance("TLSv1");
+      SSLContext context = SSLContext.getInstance(tlsVersion);
 
       X509TrustManager tm = SocketFactoryCreator.getSSLTrustManager(certificateValidator());
       SecureRandom r = new SecureRandom();
@@ -178,15 +179,6 @@ public class ClientConfiguration {
     Jackson2ObjectMapperBuilder jacksonBuilder = new Jackson2ObjectMapperBuilder();
     jacksonBuilder.filters(new SimpleFilterProvider().setFailOnUnknownId(false));
     return jacksonBuilder;
-  }
-
-  @Bean
-  public CacheManager caffeineCacheManager() {
-
-    CaffeineCacheManager manager = new CaffeineCacheManager("introspect", "userinfo");
-    manager.setCacheSpecification("expireAfterWrite=60s, maximumSize=500");
-
-    return manager;
   }
 
   @Bean

--- a/oidc-client/src/main/resources/application.yml
+++ b/oidc-client/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
   profiles:
     active: test
 
+  cache:
+    type: ${CLIENT_CACHE:caffeine}
+    cache-names: introspect,userinfo
+    caffeine:
+      spec: maximumSize=500,expireAfterWrite=60s
+
 oidc:
   clients:
       - issuer-url: http://localhost:8080/
@@ -24,6 +30,9 @@ oidc:
 x509:
   trustAnchorsDir: ${X509_TRUST_ANCHORS_DIR:/etc/grid-security/certificates}
   trustAnchorsRefreshMsec: ${X509_TRUST_ANCHORS_REFRESH:14400}
+  
+tls:
+  version: ${CLIENT_TLS_VERSION:TLSv1.2}
 
 security:
   basic:

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 		<mitreid.version>1.3.0.cnaf-SNAPSHOT</mitreid.version>
 		<voms.version>3.2.0</voms.version>
-		<caffeine.version>2.5.6</caffeine.version>
+		<caffeine.version>2.6.2</caffeine.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<json-path.version>2.4.0</json-path.version>
 		<jackson.version>2.8.9</jackson.version>


### PR DESCRIPTION
This PR introduce this changes:
- remove hardcoded TLS version and make it configurabile through configuration file and environment variable;
- moved caffeine cache configuration from code to configuration file;
- add actuator to introduce health endpoint.